### PR TITLE
Update librespot to v0.4.1

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -7,7 +7,7 @@ WORKDIR /build
 
 RUN git clone https://github.com/librespot-org/librespot.git \
     && cd librespot \
-    && git checkout v0.3.1 \
+    && git checkout v0.4.1 \
     && cargo build --release --no-default-features
 
 


### PR DESCRIPTION
This should fix issues with libmdns not being able to resolve packages from other network subnets.
As described here https://github.com/librespot-org/libmdns/issues/19